### PR TITLE
subset mu alongside prob and P

### DIFF
--- a/R/computational_functions.R
+++ b/R/computational_functions.R
@@ -601,6 +601,8 @@ fit_hmm <- function (x, sd,
   P = P[idx_comp, idx_comp, drop=FALSE]
   P <- P / rowSums(P)
 
+  mu <- mu[idx_comp]
+
   while( iter < maxiter ){
 
     alpha_hat = matrix(nrow = length(X), ncol=K)


### PR DESCRIPTION
This was added in 9f89333 and lost in the fc806a5 restructure --- should be a bug